### PR TITLE
Updated src url of the  ansible-cvmfs-client role

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -46,7 +46,7 @@ roles:
     version: v2.0.2
 
   - name: ansible-cvmfs-client
-    src: https://git.computecanada.ca/cc-cvmfs-public/ansible-cvmfs-client.git
+    src: https://github.com/cvmfs-contrib/ansible-cvmfs-client.git
     scm: git
     version: master
 


### PR DESCRIPTION
the (old) URL README mention they have moved the role:
https://git.computecanada.ca/cc-cvmfs-public/ansible-cvmfs-client